### PR TITLE
fix: typo in config

### DIFF
--- a/SG_code/Config/motion_fine_gpt_rq_level_1.yaml
+++ b/SG_code/Config/motion_fine_gpt_rq_level_1.yaml
@@ -77,7 +77,7 @@ structure_vqvae:
 
 structure_gpt:
   name: Fine_GPT2_2part
-  layer_no: 3
+  layer_no: 1
   block_size: 15
   n_music: 437
   n_music_emb: 768
@@ -118,7 +118,7 @@ optimizer:
     gamma: 0.4
 
 exp_name: train_fine_gpt
-log_name: layer_number_3
+log_name: layer_number_1
 need_not_train_data: 0
 need_not_test_data: 1
 

--- a/SG_code/Config/motion_fine_gpt_rq_level_2.yaml
+++ b/SG_code/Config/motion_fine_gpt_rq_level_2.yaml
@@ -77,7 +77,7 @@ structure_vqvae:
 
 structure_gpt:
   name: Fine_GPT2_2part
-  layer_no: 3
+  layer_no: 2
   block_size: 15
   n_music: 437
   n_music_emb: 768
@@ -118,7 +118,7 @@ optimizer:
     gamma: 0.4
 
 exp_name: train_fine_gpt
-log_name: layer_number_3
+log_name: layer_number_2
 need_not_train_data: 0
 need_not_test_data: 1
 


### PR DESCRIPTION
Previously, the layer_no value in the config was set to 3 across all instances. However, considering [this line](https://github.com/LuMen-ze/Semantic-Gesticulator-Official/blob/f26e0a1587a418428431203c5da1246c78536bc7/SG_code/motion_gpt.py#L81) and [this line](https://github.com/LuMen-ze/Semantic-Gesticulator-Official/blob/f26e0a1587a418428431203c5da1246c78536bc7/SG_code/Model/fine_gpt2_2part.py#L32), this incorrect setting could lead to significant issues during training.